### PR TITLE
feat: handle upcoming streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 venv/
 update_instructions.md
 todo.txt
-assignments.json
+subscriptions.json

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Kill all tmux sessions:
 ```
 tmux kill-server
 ```
+View all running tmux sessions:
+```
+tmux ls
+```
 
 ## Commands:
 /assign: Assign a streamer to a route.

--- a/main.py
+++ b/main.py
@@ -191,11 +191,11 @@ async def send_embed(live_videos, upcoming_videos, streamer, discord_channel_id)
             embed.set_thumbnail(
                 url=company_icons.get(streamer.company, "")
             )
-            embed.add_field(name=":clock3: Upcoming", value=f"<t:{int(datetime.strptime(scheduledStartTime, "%Y-%m-%dT%H:%M:%SZ").timestamp())}:t>", inline=True)
+            embed.add_field(name=":clock3: Upcoming", value=f"<t:{int(datetime.strptime(scheduledStartTime, '%Y-%m-%dT%H:%M:%SZ').timestamp())}:t>", inline=True)
             # embed.add_field(name="Viewers", value=f"{} watching now", inline=True) # TODO: use "concurrentViewers" field in YT API response JSON
             thumbnail_url = f"https://img.youtube.com/vi/{video_id}/hqdefault.jpg"
             embed.set_image(url=thumbnail_url)
-            embed.set_footer(text=f"Youtube • <t:{int(datetime.strptime(scheduledStartTime, "%Y-%m-%dT%H:%M:%SZ").timestamp())}:d> <t:{int(datetime.strptime(scheduledStartTime, "%Y-%m-%dT%H:%M:%SZ").timestamp())}:t>")
+            embed.set_footer(text=f"Youtube • <t:{int(datetime.strptime(scheduledStartTime, '%Y-%m-%dT%H:%M:%SZ').timestamp())}:d> <t:{int(datetime.strptime(scheduledStartTime, '%Y-%m-%dT%H:%M:%SZ').timestamp())}:t>")
             await channel.send(embed=embed)
 
     # for live,
@@ -220,7 +220,7 @@ async def send_embed(live_videos, upcoming_videos, streamer, discord_channel_id)
             # embed.add_field(name="Viewers", value=f"{} watching now", inline=True) # TODO: use "concurrentViewers" field in YT API response JSON
             thumbnail_url = f"https://img.youtube.com/vi/{video_id}/hqdefault.jpg"
             embed.set_image(url=thumbnail_url)
-            embed.set_footer(text=f"Youtube • <t:{int(datetime.strptime(scheduledStartTime, "%Y-%m-%dT%H:%M:%SZ").timestamp())}:d> <t:{int(datetime.strptime(scheduledStartTime, "%Y-%m-%dT%H:%M:%SZ").timestamp())}:t>")
+            embed.set_footer(text=f"Youtube • <t:{int(datetime.strptime(scheduledStartTime, '%Y-%m-%dT%H:%M:%SZ').timestamp())}:d> <t:{int(datetime.strptime(scheduledStartTime, '%Y-%m-%dT%H:%M:%SZ').timestamp())}:t>")
             await channel.send(embed=embed)
 
 def get_channel_name(channel_id: str) -> str:

--- a/main.py
+++ b/main.py
@@ -428,7 +428,7 @@ async def list_ids(interaction: discord.Interaction):
 
     await interaction.response.send_message(embed=embed)
 
-@tasks.loop(minute=5) # TODO: Change to 3 or 5 minutes when done testing
+@tasks.loop(minutes=5) # TODO: Change to 3 or 5 minutes when done testing
 async def periodic_live_stream_check():
     await check_for_live_streams()
 

--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ def fetch_recent_video_ids(channel_id):
 
 def check_videos_live(video_ids):
     """Check if videos are live using the YouTube API."""
-    live_videos = [] # (video_id, channel_title, title, link) tuples
+    live_videos = [] # (video_id, channel_title, title, link, scheduledStartTime) tuples
     upcoming_videos = [] # (video_id, channel_title, title, link, scheduledStartTime) tuples
     if not video_ids:
         return live_videos # No videos to check
@@ -128,7 +128,8 @@ def check_videos_live(video_ids):
                 title = item["snippet"]["title"]
                 channel_title = item["snippet"]["channelTitle"]
                 link = f"https://www.youtube.com/watch?v={video_id}"
-                live_videos.append((video_id, channel_title, title, link))
+                scheduledStartTime = item["liveStreamingDetails"]["scheduledStartTime"]
+                live_videos.append((video_id, channel_title, title, link, scheduledStartTime))
             elif snippet.get("liveBroadcastContent") == "upcoming": # Check if the stream is upcoming
                 video_id = item["id"]
                 title = item["snippet"]["title"]

--- a/main.py
+++ b/main.py
@@ -312,7 +312,7 @@ async def unsubscribe_from_channel(interaction: discord.Interaction, streamer_ch
                 del subscriptions[discord_channel_id]
             break
     else:
-        await interaction.response.send_message(f"⚠️ This channel is not subscribed to `{streamer_name}`.")
+        await interaction.response.send_message(f"⚠️ This channel is not subscribed to `{streamer_name} ({streamer_channel_id})`.")
 
     save_subscriptions()
 

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ youtube_channel_ids = [
     # "UCBURM8S4LH7cRZ0Clea9RDA", # Reimu Endou
     # "UChKXd7oqD18qiIYBoRIHTlw", # Meloco Kyoran
     # "UCR6qhsLpn62WVxCBK1dkLow", # Enna Alouette
+    # "UC47rNmkDcNgbOcM-2BwzJTQ", "Millie Parfait"
 
     # "UCGhqxhovNfaPBpxfCruy9EA", # Fulgur Ovid
 
@@ -310,6 +311,32 @@ async def unassign_from_discord_channel(interaction: discord.Interaction, stream
         await interaction.response.send_message(f"⚠️ This channel is not subscribed to `{streamer_name}`.")
 
     save_assignments()
+
+@tree.command(name="ids", description="View list of streamer channel ids available to assign")
+async def list_ids(interaction: discord.Interaction):
+    # View list of streamer channel ids
+    discord_channel_id = interaction.channel_id
+    
+    # assignment_names = [f"`{streamer.name}`" for streamer in channel_assignments.get("streamers")]
+    # formatted_names = ", ".join(assignment_names) if assignment_names else "No streamers assigned."
+    # await interaction.response.send_message(f"✅ This Discord channel is subscribed to notifications for: {formatted_names}")
+
+    channel = bot.get_channel(discord_channel_id)
+    if channel:
+        embed = discord.Embed(
+            color=discord.Color.blue(),
+            title="List of channel IDs",
+            description="Elira Pendora: UCIeSUTOTkF9Hs7q3SGcO-Ow"
+        )
+        # embed.set_author(
+        #     name=channel_title,
+        # )
+        # embed.add_field(name=":clock3: Live", value=f"<t:{int(time.time())}:R>", inline=True)
+        # embed.add_field(name="Viewers", value=f"{} watching now", inline=True) # TODO: use "concurrentViewers" field in YT API response JSON
+        # thumbnail_url = f"https://img.youtube.com/vi/{video_id}/hqdefault.jpg"
+        # embed.set_image(url=thumbnail_url)
+        # embed.set_footer(text="Youtube • 7/30/2023 4:01 PM") # TODO: Add stream date
+        await channel.send(embed=embed)
 
 @tasks.loop(minutes=5) # TODO: Change to 3 or 5 minutes when done testing
 async def periodic_live_stream_check():

--- a/main.py
+++ b/main.py
@@ -27,14 +27,18 @@ youtube_channel_ids = [
     # "UCu-J8uIXuLZh16gG-cT1naw", # Finana Ryugu
 
     # "UC4WvIIAo89_AzGUh1AZ6Dkg", # Rosemi Lovelock
+    # "UCgA2jKRkqpY_8eysPUs8sjw", # Petra Gurin
 
-    # "UCwaS8_S7kMiKA3izlTWHbQg",  # Maria Marionette
-    # "UCBURM8S4LH7cRZ0Clea9RDA", # Reimu Endou
-    # "UChKXd7oqD18qiIYBoRIHTlw", # Meloco Kyoran
     # "UCR6qhsLpn62WVxCBK1dkLow", # Enna Alouette
     # "UC47rNmkDcNgbOcM-2BwzJTQ", "Millie Parfait"
+    # "UCBURM8S4LH7cRZ0Clea9RDA", # Reimu Endou
+    
+
+    # "UCwaS8_S7kMiKA3izlTWHbQg",  # Maria Marionette
 
     # "UCGhqxhovNfaPBpxfCruy9EA", # Fulgur Ovid
+
+    # "UChKXd7oqD18qiIYBoRIHTlw", # Meloco Kyoran
 
     # # Hololive EN Girls
     # Myth
@@ -314,29 +318,49 @@ async def unassign_from_discord_channel(interaction: discord.Interaction, stream
 
 @tree.command(name="ids", description="View list of streamer channel ids available to assign")
 async def list_ids(interaction: discord.Interaction):
-    # View list of streamer channel ids
-    discord_channel_id = interaction.channel_id
-    
-    # assignment_names = [f"`{streamer.name}`" for streamer in channel_assignments.get("streamers")]
-    # formatted_names = ", ".join(assignment_names) if assignment_names else "No streamers assigned."
-    # await interaction.response.send_message(f"✅ This Discord channel is subscribed to notifications for: {formatted_names}")
+    embed = discord.Embed(
+        color=discord.Color.blue(),
+        title="List of channel IDs",
+    )
+    embed.add_field(name=":rainbow: Nijisanji", value=f"""
+    Elira Pendora: UCIeSUTOTkF9Hs7q3SGcO-Ow
+    Finana Ryugu: UCu-J8uIXuLZh16gG-cT1naw
 
-    channel = bot.get_channel(discord_channel_id)
-    if channel:
-        embed = discord.Embed(
-            color=discord.Color.blue(),
-            title="List of channel IDs",
-            description="Elira Pendora: UCIeSUTOTkF9Hs7q3SGcO-Ow"
-        )
-        # embed.set_author(
-        #     name=channel_title,
-        # )
-        # embed.add_field(name=":clock3: Live", value=f"<t:{int(time.time())}:R>", inline=True)
-        # embed.add_field(name="Viewers", value=f"{} watching now", inline=True) # TODO: use "concurrentViewers" field in YT API response JSON
-        # thumbnail_url = f"https://img.youtube.com/vi/{video_id}/hqdefault.jpg"
-        # embed.set_image(url=thumbnail_url)
-        # embed.set_footer(text="Youtube • 7/30/2023 4:01 PM") # TODO: Add stream date
-        await channel.send(embed=embed)
+    Rosemi Lovelock: UC4WvIIAo89_AzGUh1AZ6Dkg
+    Petra Gurin: UCgA2jKRkqpY_8eysPUs8sjw
+
+    Enna Alouette: UCR6qhsLpn62WVxCBK1dkLow
+    Millie Parfait: UC47rNmkDcNgbOcM-2BwzJTQ
+    Reimu Endou: UCBURM8S4LH7cRZ0Clea9RDA
+    
+    Maria Marionette: UCwaS8_S7kMiKA3izlTWHbQg
+    Fulgur Ovid: UCGhqxhovNfaPBpxfCruy9EA
+    Meloco Kyoran: UChKXd7oqD18qiIYBoRIHTlw
+    """, inline=False)
+    embed.add_field(name=":arrow_forward: Hololive", value=f"""
+    Takanashi Kiara: UCHsx4Hqa-1ORjQTh9TYDhww  
+    Mori Calliope: UCL_qhgtOy0dy1Agp8vkySQg  
+    Ninomae Ina'nis: UCMwGHR0BTZuLsmjY_NT5Pwg  
+    Gawr Gura: UCoSrY_IQQVpmIRZ9Xf-y93g  
+
+    IRyS: UC8rcEBzJSleTkf_-agPM20g  
+    Ceres Fauna: UCO_aKKYxn4tvrqPjcTzZ6EQ  
+    Ouro Kronii: UCmbs8T6MWqUHP1tIQvSgKrg  
+    Nanashi Mumei: UC3n5uGu18FoCy23ggWWp8tA  
+    Hakos Baelz: UCgmPnx-EEeOrZSg5Tiw7ZRQ  
+
+    Shiori Novella: UCgnfPPb9JI3e9A4cXHnWbyg  
+    Koseki Bijou: UC9p_lqQ0FEDz327Vgf5JwqA  
+    Nerissa Ravencroft: UC_sFNM0z0MWm9A6WlKPuMMg  
+    FUWAMOCO: UCt9H_RpQzhxzlyBxFqrdHqA  
+
+    Elizabeth Rose Bloodflame: UCW5uhrG1eCBYditmhL0Ykjw  
+    Raora Panthera: UCl69AEx4MdqMZH7Jtsm7Tig  
+    Gigi Murin: UCDHABijvPBnJm7F-KlNME3w  
+    Cecilia Immergreen: UCvN5h1ShZtc7nly3pezRayg  
+    """, inline=False)
+
+    await interaction.response.send_message(embed=embed)
 
 @tasks.loop(minutes=5) # TODO: Change to 3 or 5 minutes when done testing
 async def periodic_live_stream_check():

--- a/main.py
+++ b/main.py
@@ -398,7 +398,7 @@ async def list_ids(interaction: discord.Interaction):
 
     await interaction.response.send_message(embed=embed)
 
-@tasks.loop(seconds=5) # TODO: Change to 3 or 5 minutes when done testing
+@tasks.loop(minutes=5) # TODO: Change to 3 or 5 minutes when done testing
 async def periodic_live_stream_check():
     await check_for_live_streams()
 

--- a/main.py
+++ b/main.py
@@ -308,7 +308,7 @@ def load_subscriptions():
         subscriptions = {}
 
 """Discord Bot Functions"""
-@tree.command(name="listsubscriptions", description="List the streamers the Discord channel is subscribed to alerts for")
+@tree.command(name="subscriptions", description="List the streamers the Discord channel is subscribed to alerts for")
 async def list_subscriptions(interaction: discord.Interaction):
     # View list of subscriptions
     discord_channel_id = interaction.channel_id
@@ -383,13 +383,14 @@ async def unsubscribe_from_channel(interaction: discord.Interaction, streamer_ch
 
     save_subscriptions()
 
-@tree.command(name="ids", description="View quick list of streamer channel ids available to subscribe to")
+@tree.command(name="list", description="View quick list of streamer channel ids available to subscribe to")
 async def list_ids(interaction: discord.Interaction):
     embed = discord.Embed(
         color=discord.Color.blue(),
         title="List of channel IDs",
     )
     embed.add_field(name=":rainbow: Nijisanji", value=f"""
+    ```
     Elira Pendora: UCIeSUTOTkF9Hs7q3SGcO-Ow
     Finana Ryugu: UCu-J8uIXuLZh16gG-cT1naw
 
@@ -403,8 +404,10 @@ async def list_ids(interaction: discord.Interaction):
     Maria Marionette: UCwaS8_S7kMiKA3izlTWHbQg
     Fulgur Ovid: UCGhqxhovNfaPBpxfCruy9EA
     Meloco Kyoran: UChKXd7oqD18qiIYBoRIHTlw
+    ```
     """, inline=False)
     embed.add_field(name=":arrow_forward: Hololive", value=f"""
+    ```
     Takanashi Kiara: UCHsx4Hqa-1ORjQTh9TYDhww  
     Mori Calliope: UCL_qhgtOy0dy1Agp8vkySQg  
     Ninomae Ina'nis: UCMwGHR0BTZuLsmjY_NT5Pwg  
@@ -424,6 +427,7 @@ async def list_ids(interaction: discord.Interaction):
     Raora Panthera: UCl69AEx4MdqMZH7Jtsm7Tig  
     Gigi Murin: UCDHABijvPBnJm7F-KlNME3w  
     Cecilia Immergreen: UCvN5h1ShZtc7nly3pezRayg  
+    ```
     """, inline=False)
 
     await interaction.response.send_message(embed=embed)

--- a/main.py
+++ b/main.py
@@ -121,7 +121,6 @@ def check_videos_live(video_ids):
     response = requests.get(url, params)
     if response.status_code == 200:
         data = response.json()
-        print(data) # TODO: Delete
         for item in data.get("items", []):
             snippet = item.get("snippet", {})
             if snippet.get("liveBroadcastContent") == "live": # Check if the stream has started


### PR DESCRIPTION
Add command for listing yt channel ids.
Refactor to use "subscribe" instead of "assign" wording.
Send alerts for upcoming streams, in addition to live streams.